### PR TITLE
Update BIS links

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                 <p>This website is <b>NOT</b> affiliated with or in any way associated with the Bureau of Industry and Security or National Security Agency.</p>
                 <p>
                     This website only helps to generate correct formatted CSV files as required per
-                    <a href="http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&SID=4150cfbf028e9a85574385383a581f47&h=L&mc=true&n=pt15.2.742&r=PART&ty=HTML#ap15.2.742_119.6" target="_blank">Supp. 8 to Part 742</a>.
+                    <a href="https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742#ap15.2.742_119.6" target="_blank">Supp. 8 to Part 742</a>.
                 </p>
             </div>
 
@@ -106,8 +106,8 @@
             <div class="section my-4 p-4">
                 <h3>Example</h3>
                 <p>
-                    The table in this <a href="https://www.bis.doc.gov/index.php/component/docman/?task=doc_download&gid=1675" target="_blank">sample annual self-classification report</a> provides an example of the various fields required within the Annual
-                    Self-Classification Report as required per <a href="http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=1&SID=4150cfbf028e9a85574385383a581f47&h=L&mc=true&n=pt15.2.742&r=PART&ty=HTML#ap15.2.742_119.6" target="_blank">Supp. 8 to Part 742</a>,
+                    The table in this <a href="https://www.bis.gov/media/documents/sample-annual-self-classification-report.xlsx" target="_blank">sample annual self-classification report</a> provides an example of the various fields required within the Annual
+                    Self-Classification Report as required per <a href="https://www.bis.gov/regulations/ear/742#supplement-8-742" target="_blank">Supp. 8 to Part 742</a>,
                     section (b) and demonstrates how various instructions & tips published in Supplement 8 to part 742 works out in practice.
                 </p>
                 <div class="form-group">
@@ -115,7 +115,7 @@
                 </div>
                 <h3>App Store Connect Example</h3>
                 <p>
-                    If your app uses exempt forms of encryption, you might alternatively be required to submit a year-end self-classification report to the U.S. government.  To learn more, see <a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/4-reports-and-reviews/a-annual-self-classification" target="_blank">How to file an Annual Self Classification Report</a> and the exempt App Store sample.
+                    If your app uses exempt forms of encryption, you might alternatively be required to submit a year-end self-classification report to the U.S. government.  To learn more, see <a href="https://www.bis.gov/learn-support/encryption-controls/annual-self-classification" target="_blank">How to file an Annual Self Classification Report</a> and the exempt App Store sample.
                 </p>
                 <div class="form-group">
                     <button type="button" onclick="loadAppStoreSample()" class="btn btn-primary">Load App Store Sample</button>
@@ -397,7 +397,7 @@ max-width: 95%;">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">Quick Reference Guide
-Category 5 Part 2 - Information Security: ECCN 5X <small><a href="https://www.bis.doc.gov/index.php/documents/new-encryption/1652-cat-5-part-2-quick-reference-guide/file" target="_blank">PDF Version</a></small></h5>
+Category 5 Part 2 - Information Security: ECCN 5X <small><a href="https://www.bis.gov/media/documents/new-version2-cat-5-part-2-quick-reference-guide-july-2017.pdf" target="_blank">PDF Version</a></small></h5>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
@@ -418,17 +418,17 @@ Category 5 Part 2 - Information Security: ECCN 5X <small><a href="https://www.bi
                                     <td>
                                         “Information security” systems, equipment and “components”
                                         <ul>
-                                            <li><b>.a</b> – Designed or modified to use '<a href="https://www.bis.doc.gov/index.php/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/i-crypto-for-data-confidentiality" target="_blank">cryptography for data confidentiality</a>'
-having '<a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/ii-key-length" target="_blank">in excess of 56 bits of symmetric cryptographic strength key length, or equivalent</a>', where that cryptographic capability is usable without "<a href="https://www.bis.doc.gov/index.php/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/iii-cryptographic-activation" target="_blank">cryptographic activation</a>" or has been activated, as follows:
+                                            <li><b>.a</b> – Designed or modified to use '<a href="https://www.bis.gov/learn-support/encryption-controls/cryptography-for-data-confidentiality" target="_blank">cryptography for data confidentiality</a>'
+having '<a href="https://www.bis.gov/learn-support/encryption-controls/key-length" target="_blank">in excess of 56 bits of symmetric cryptographic strength key length, or equivalent</a>', where that cryptographic capability is usable without "<a href="https://www.bis.gov/learn-support/encryption-controls/cryptographic-activation" target="_blank">cryptographic activation</a>" or has been activated, as follows:
                                                 <ul>
-                                                    <li><a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/iv-5a002-a-1-a-4" target="_blank"><b>a.1</b></a> Items having "information security" as a primary function;</li>
-                                                    <li><a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/iv-5a002-a-1-a-4" target="_blank"><b>a.2</b></a> Digital communication or networking systems, equipment or
+                                                    <li><a href="https://www.bis.gov/learn-support/encryption-controls/5a002-a.1-a.5" target="_blank"><b>a.1</b></a> Items having "information security" as a primary function;</li>
+                                                    <li><a href="https://www.bis.gov/learn-support/encryption-controls/5a002-a.1-a.5" target="_blank"><b>a.2</b></a> Digital communication or networking systems, equipment or
 components, not specified in paragraph 5A002.a.1.;</li>
-                                                    <li><a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/iv-5a002-a-1-a-4" target="_blank"><b>a.3</b></a> Computers, other items having information storage or
+                                                    <li><a href="https://www.bis.gov/learn-support/encryption-controls/5a002-a.1-a.5" target="_blank"><b>a.3</b></a> Computers, other items having information storage or
 processing as a primary function, and components therefor, not specified in paragraphs 5A002.a.1. or 5A002.a.2.;
 N.B. For operating systems, see also 5D002.a.1. and 5D002.c.1.</li>
                                                     <li>
-                                                        <a href="https://www.bis.doc.gov/index.php/policy-guidance/encryption/2-items-in-cat-5-part-2/a-5a002-a-and-5d002-c-1/iv-5a002-a-1-a-4" target="_blank"><b>a.4</b></a> - Items, not specified in paragraphs 5A002.a.1. to a.3., where the 'cryptography for data confidentiality' having 'in excess of 56 bits of symmetric cryptographic strength key length, or equivalent' meets all of the following:
+                                                        <a href="https://www.bis.gov/learn-support/encryption-controls/5a002-a.1-a.5" target="_blank"><b>a.4</b></a> - Items, not specified in paragraphs 5A002.a.1. to a.3., where the 'cryptography for data confidentiality' having 'in excess of 56 bits of symmetric cryptographic strength key length, or equivalent' meets all of the following:
                                                         <ul>
                                                             <li><b>a.</b> It supports a non-primary function of the item; and</li>
                                                             <li><b>b.</b> It is performed by incorporated equipment or


### PR DESCRIPTION
The BIS website, https://bis.gov, was updated so all links broke. I've updated them in this PR.

I used a combination of searching the BIS website and the Wayback Machine to figure out the new links.

**Resource links**

- https://www.bis.gov/learn-support/encryption-controls